### PR TITLE
Lsp autoconfig rework.

### DIFF
--- a/ftplugin/java.lua
+++ b/ftplugin/java.lua
@@ -38,7 +38,7 @@ local config = {
     "--add-opens",
     "java.base/java.lang=ALL-UNNAMED",
     "-jar",
-    vim.fn.stdpath "data" .. "/mason/packages/jdtls/plugins/org.eclipse.equinox.launcher_1.6.500.v20230717-2134.jar", -- IMPORTANT
+    vim.fn.glob(vim.fn.stdpath "data" .. "/mason/packages/jdtls/plugins/org.eclipse.equinox.launcher_*.jar", 1), -- IMPORTANT
     "-configuration",
     vim.fn.stdpath "data" .. "/mason/packages/jdtls/config_linux", -- IMPORTANT
     "-data",

--- a/ftplugin/java.lua
+++ b/ftplugin/java.lua
@@ -14,12 +14,12 @@ end
 
 local bundles = {
   vim.fn.glob(
-    vim.fn.stdpath "data" .. "/debugging/java-debug/com.microsoft.java.debug.plugin/target/com.microsoft.java.debug.plugin-*.jar",
+    vim.fn.stdpath "data" .. "/mason/share/java-debug-adapter/com.microsoft.java.debug.plugin-*.jar",
     1
   ),
 }
 
-vim.list_extend(bundles, vim.split(vim.fn.glob(vim.fn.stdpath "data" .. "/debugging/vscode-java-test/server/*.jar", 1), "\n"))
+vim.list_extend(bundles, vim.split(vim.fn.glob(vim.fn.stdpath "data" .. "/mason/share/java-test/*.jar", 1), "\n"))
 
 local config = {
   on_attach = on_attach,

--- a/lua/modules/core/debug/dap.lua
+++ b/lua/modules/core/debug/dap.lua
@@ -30,41 +30,41 @@ M[#M + 1] = {
       -- dapui.close()
     end
 
-    dap.configurations.c = {
-      {
-        name = "Launch file",
-        type = "codelldb",
-        request = "launch",
-        program = function()
-          return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
-        end,
-        cwd = "${workspaceFolder}",
-        stopOnEntry = false,
-      },
-    }
-
-    dap.adapters.lldb = {
-      type = "executable",
-      command = "/usr/bin/lldb-vscode", -- adjust as needed, must be absolute path
-      name = "lldb",
-    }
-
-    dap.configurations.cpp = {
-      {
-        name = "Launch",
-        type = "lldb",
-        request = "launch",
-        program = function()
-          return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
-        end,
-        cwd = "${workspaceFolder}",
-        stopOnEntry = false,
-        args = {},
-        -- add other configs hereby
-      },
-    }
-
-    dap.configurations.c = dap.configurations.cpp
+    -- dap.configurations.c = {
+    --   {
+    --     name = "Launch file",
+    --     type = "codelldb",
+    --     request = "launch",
+    --     program = function()
+    --       return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
+    --     end,
+    --     cwd = "${workspaceFolder}",
+    --     stopOnEntry = false,
+    --   },
+    -- }
+    --
+    -- dap.adapters.lldb = {
+    --   type = "executable",
+    --   command = "/usr/bin/lldb-vscode", -- adjust as needed, must be absolute path
+    --   name = "lldb",
+    -- }
+    --
+    -- dap.configurations.cpp = {
+    --   {
+    --     name = "Launch",
+    --     type = "lldb",
+    --     request = "launch",
+    --     program = function()
+    --       return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
+    --     end,
+    --     cwd = "${workspaceFolder}",
+    --     stopOnEntry = false,
+    --     args = {},
+    --     -- add other configs hereby
+    --   },
+    -- }
+    --
+    -- dap.configurations.c = dap.configurations.cpp
 
     dap.adapters.godot = {
       type = "server",
@@ -82,9 +82,9 @@ M[#M + 1] = {
       },
     }
 
-    local dap_install = require "dap-install"
-    dap_install.setup {}
-    dap_install.config("python", {})
+    -- local dap_install = require "dap-install"
+    -- dap_install.setup {}
+    -- dap_install.config("python", {})
   end,
 }
 

--- a/lua/modules/core/languages/rust-tools.lua
+++ b/lua/modules/core/languages/rust-tools.lua
@@ -1,5 +1,5 @@
 -- Update this path
-local extension_path = vim.fn.stdpath "data" .. "/home/niamh/.local/share/nvim/mason/packages/codelldb/extension"
+local extension_path = vim.fn.stdpath "data" .. "/mason/packages/codelldb/extension"
 local codelldb_path = extension_path .. "adapter/codelldb"
 local liblldb_path = extension_path .. "lldb/lib/liblldb.so" -- MacOS: This may be .dylib
 

--- a/lua/modules/core/languages/rust-tools.lua
+++ b/lua/modules/core/languages/rust-tools.lua
@@ -1,5 +1,5 @@
 -- Update this path
-local extension_path = vim.env.HOME .. "/.vscode/extensions/vadimcn.vscode-lldb-1.9.0/"
+local extension_path = vim.fn.stdpath "data" .. "/home/niamh/.local/share/nvim/mason/packages/codelldb/extension"
 local codelldb_path = extension_path .. "adapter/codelldb"
 local liblldb_path = extension_path .. "lldb/lib/liblldb.so" -- MacOS: This may be .dylib
 

--- a/lua/modules/core/lsp/lsp.lua
+++ b/lua/modules/core/lsp/lsp.lua
@@ -96,8 +96,7 @@ function M.config()
     end
   end
 
-  attach_servers(require("utils").managed)
-  attach_servers(require("utils").unmanaged.servers)
+  attach_servers(require("utils").auto_configure)
 end
 
 return M

--- a/lua/modules/core/lsp/mason.lua
+++ b/lua/modules/core/lsp/mason.lua
@@ -8,8 +8,14 @@ local M = {
       lazy = true,
     },
     {
-      "rcarriga/nvim-dap-ui",
+      "williamboman/mason-null-ls.nvim",
+      lazy = true,
     },
+    {
+      "williamboman/mason-nvim-dap.nvim",
+      lazy = true,
+    },
+    { "rcarriga/nvim-dap-ui" },
   },
 }
 
@@ -25,15 +31,20 @@ M.opts = {
   log_level = vim.log.levels.INFO,
   max_concurrent_installers = 4,
 }
-
 function M.config(_, opts)
-  local lsp_opts = {
-    ensure_installed = require("utils").managed,
-    automatic_installation = true,
-  }
-
   require("mason").setup(opts)
-  require("mason-lspconfig").setup(lsp_opts)
+  require("mason-lspconfig").setup {
+    ensure_installed = require("utils").ensure_installed.lsp,
+    automatic_installation = false,
+  }
+  require("mason-null-ls").setup {
+    ensure_installed = require("utils").ensure_installed.tools,
+    automatic_installation = false,
+  }
+  require("mason-nvim-dap").setup {
+    ensure_installed = require("utils").ensure_installed.dap,
+    automatic_installation = false,
+  }
 end
 
 return M

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -20,77 +20,36 @@ local install_and_configure = {
 }
 
 local auto_configure = {
-  "gdscript"
+  "gdscript",
 }
 
 local ensure_installed = {
-  "jdtls",
-}
-
-local M = {
-  auto_configure = vim.list_extend(install_and_configure, auto_configure),
-  ensure_installed = vim.list_extend(install_and_configure, ensure_installed),
-}
-
--- Utils Table
-local N = {}
-
-N.managed = {
-  -- Lua & System
-  lua_ls = "lua_ls", -- Lua LSP
-  bashls = "bashls", -- Bash LSP
-
-  -- Markup & Data Formats
-  -- "typst-lsp",            -- Tyspt LSP
-  jsonls = "jsonls", -- JSON LSP
-  yamlls = "yamlls", -- YAML LSP
-  html = "html", -- HTML LSP
-
-  -- Scripting/Interpreted
-  tsserver = "tsserver", -- Typescript & Javascript LSP
-  eslint = "eslint", -- Typescript & Javascript Linting
-  svelte = "svelte",
-  vuels = "vuels",
-  pyright = "pyright", -- Python LSP
-
-  -- Mixed
-  csharp_ls = "csharp_ls", -- C# via csharp-language-server
-  -- omnisharp = "omnisharp",         -- C# via omnisharp-roslyn
-
-  -- Compiled
-  clangd = "clangd", -- C/C++ LSP
-  gopls = "gopls", -- Go LSP & Formatting
-
-  -- Build Tools
-  cmake = "cmake", -- CMake LSP
-
-  --Styling
-  cssls = "cssls", -- CSS LSP
-}
-
--- Names only for lspconfig.
-N.unmanaged = {
-  servers = {
-    gdscript = "gdscript", -- gdscript LSP handled by Godot
+  lsp = {
+    "jdtls",
+    "rust_analyzer",
   },
-  linters = {
-    -- "cmakelang",
-    -- "cmakelint",
-    -- "checkstyle",
-    gdtoolkit = "gdtoolkit",
+  dap = {
+    "javatest",
+    "javadbg",
+    "python",
+    "codelldb"
   },
-  formatters = {
-    black = "black",
-    ["clang-format"] = "clang-format",
-    -- "cmakelang",
-    csharpier = "csharpier",
-    gdtoolkit = "gdtoolkit",
-    golines = "golines",
-    ["goimports-reviser"] = "goimports-reviser",
-    -- gofumpt = "gofumpt",
-    -- goimports = "goimports",
-    stylua = "stylua",
+  tools = {
+    "gdtoolkit",
+    "black",
+    "flake8",
+    "prettier",
+    "clang-format",
+    "csharpier",
+    "google-java-format",
+    "stylua",
+    "goimports-revirser",
+    "golines",
   },
 }
 
-return N
+ensure_installed.lsp = vim.list_extend(ensure_installed.lsp, install_and_configure)
+return {
+  auto_configure = vim.list_extend(auto_configure, install_and_configure),
+  ensure_installed = ensure_installed,
+}

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -1,10 +1,41 @@
 -- Load Utility Functions
 require "utils.wrapping"
 
--- Utils Table
-local M = {}
+local install_and_configure = {
+  "lua_ls",
+  "bashls",
+  "jsonls",
+  "yamlls",
+  "html",
+  "tsserver",
+  "eslint",
+  "svelte",
+  "vuels",
+  "pyright",
+  "csharp_ls",
+  "clangd",
+  "gopls",
+  "cmake",
+  "cssls",
+}
 
-M.managed = {
+local auto_configure = {
+  "gdscript"
+}
+
+local ensure_installed = {
+  "jdtls",
+}
+
+local M = {
+  auto_configure = vim.list_extend(install_and_configure, auto_configure),
+  ensure_installed = vim.list_extend(install_and_configure, ensure_installed),
+}
+
+-- Utils Table
+local N = {}
+
+N.managed = {
   -- Lua & System
   lua_ls = "lua_ls", -- Lua LSP
   bashls = "bashls", -- Bash LSP
@@ -38,7 +69,7 @@ M.managed = {
 }
 
 -- Names only for lspconfig.
-M.unmanaged = {
+N.unmanaged = {
   servers = {
     gdscript = "gdscript", -- gdscript LSP handled by Godot
   },
@@ -62,4 +93,4 @@ M.unmanaged = {
   },
 }
 
-return M
+return N


### PR DESCRIPTION
Previously, automatically installed and configured lsp servers were a mess and there was no support for tools like linters/formatters or debug adapters. Now using some extra mason tools to make configuration of that easier.

Alongside this, we have some fixes to make the rust and java paths to said adapters less borked.

Closes #35 